### PR TITLE
Clean html to validate without errors and warnings

### DIFF
--- a/themes/gograz/assets/sass/style.scss
+++ b/themes/gograz/assets/sass/style.scss
@@ -55,7 +55,7 @@ a {
     line-height: 2.2rem;
 }
 
-#content h1 {
+#content h2 {
     text-align: center;
     font-size: 1.8rem;
     line-height: 2.6rem;

--- a/themes/gograz/layouts/meetup/single.html
+++ b/themes/gograz/layouts/meetup/single.html
@@ -3,7 +3,7 @@
 <div id="content">
     <article>
         <header>
-            <h1>{{ .Title }}</h1>
+            <h2>{{ .Title }}</h2>
         </header>
         <aside>
             {{ if .Params.location }}

--- a/themes/gograz/layouts/partials/header.html
+++ b/themes/gograz/layouts/partials/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
   <head>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="utf-8">

--- a/themes/gograz/layouts/partials/meta.html
+++ b/themes/gograz/layouts/partials/meta.html
@@ -1,4 +1,3 @@
-    <meta charset="utf-8" />
     <meta name="description" content="{{ .Description }}" />
     <meta name="keywords" content="{{ range .Keywords }}{{ . }},{{ end }}" />
     <meta name="author" content="{{ .Params.author }}" />


### PR DESCRIPTION
These changes correct the html in order to validate as valid html5 without errors and warnings.

See #9 for details.